### PR TITLE
Updated lib/manage_gitlab_project.py: fixed finding of gitmirror group

### DIFF
--- a/lib/manage_gitlab_project.py
+++ b/lib/manage_gitlab_project.py
@@ -50,7 +50,7 @@ else:
   git=gitlab.Gitlab(gitlab_url,token_secret,ssl_verify=True,api_version=gitlab_api_version)
 
 def find_group(**kwargs):
-  groups = git.groups.list()
+  groups = git.groups.list(owned=True)
   return _find_matches(groups, kwargs, False)
 
 def find_project(**kwargs):


### PR DESCRIPTION
In particular, if you have an installation with many groups, you may not get all available groups back if you call `git.groups.list()`.
But if you filter this list of groups by these that are owned by you, (and you own only one group) it is guaranteed that you only get the right group returned.